### PR TITLE
Larger search space: alpha-beta pruning

### DIFF
--- a/src/engine/AlphaBeta.php
+++ b/src/engine/AlphaBeta.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace lucidtaz\minimax\engine;
+
+/**
+ * Alpha and beta pair for use in alpha/beta pruning
+ */
+class AlphaBeta
+{
+    /**
+     * @var float
+     */
+    public $alpha;
+
+    /**
+     * @var float
+     */
+    public $beta;
+
+    public function __construct(float $alpha, float $beta)
+    {
+        $this->alpha = $alpha;
+        $this->beta = $beta;
+    }
+
+    public static function initial(): AlphaBeta
+    {
+        return new static(-INF, INF);
+    }
+
+    /**
+     * Update the constraint with new information
+     */
+    public function update(Evaluation $evaluation, NodeType $nodeType)
+    {
+        if ($nodeType == NodeType::MAX()) {
+            $this->alpha = max($this->alpha, $evaluation->score);
+        } elseif ($nodeType == NodeType::MIN()) {
+            $this->beta = min($this->beta, $evaluation->score);
+        }
+    }
+
+    /**
+     * Check whether the value ranges (alpha..inf and -inf..beta) still overlap
+     * If not, the conclusion is that the game tree branch can be pruned.
+     */
+    public function isPositiveRange(): bool
+    {
+        return $this->alpha < $this->beta;
+    }
+
+    public function __toString(): string
+    {
+        return "($this->alpha, $this->beta)";
+    }
+}

--- a/src/engine/Analytics.php
+++ b/src/engine/Analytics.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace lucidtaz\minimax\engine;
+
+/**
+ * Analytics holder
+ *
+ * This gives some insight in the evaluations done by the program.
+ *
+ * It is a result of tree traversal. Therefore this class knows how to aggregate
+ * sub-results.
+ */
+class Analytics
+{
+    /**
+     * @var int
+     */
+    public $nodesEvaluated;
+
+    /**
+     * @var int
+     */
+    public $leafNodesEvaluated;
+
+    /**
+     * @var int
+     */
+    public $internalNodesEvaluated;
+
+    public static function forLeafNode(): Analytics
+    {
+        $result = new Analytics();
+        $result->nodesEvaluated = 1;
+        $result->leafNodesEvaluated = 1;
+        $result->internalNodesEvaluated = 0;
+        return $result;
+    }
+
+    public static function forInternalNode(): Analytics
+    {
+        $result = new Analytics();
+        $result->nodesEvaluated = 1;
+        $result->leafNodesEvaluated = 0;
+        $result->internalNodesEvaluated = 1;
+        return $result;
+    }
+
+    public function add(Analytics $that)
+    {
+        $this->nodesEvaluated += $that->nodesEvaluated;
+        $this->leafNodesEvaluated += $that->leafNodesEvaluated;
+        $this->internalNodesEvaluated += $that->internalNodesEvaluated;
+    }
+}

--- a/src/engine/DecisionNode.php
+++ b/src/engine/DecisionNode.php
@@ -36,17 +36,24 @@ class DecisionNode
     private $type;
 
     /**
+     * @var AlphaBeta Constraints for alpha-beta pruning
+     */
+    private $alphaBeta;
+
+    /**
      * @param Player $objectivePlayer The Player to optimize for
      * @param GameState $state Current GameState to base decisions on
      * @param int $depthLeft Recursion limiter
      * @param NodeType $type Signifies whether to minimize or maximize the score
+     * @param AlphaBeta $alphaBeta Range of potential scores to check
      */
-    public function __construct(Player $objectivePlayer, GameState $state, int $depthLeft, NodeType $type)
+    public function __construct(Player $objectivePlayer, GameState $state, int $depthLeft, NodeType $type, AlphaBeta $alphaBeta)
     {
         $this->objectivePlayer = $objectivePlayer;
         $this->state = $state;
         $this->depthLeft = $depthLeft;
         $this->type = $type;
+        $this->alphaBeta = $alphaBeta;
     }
 
     /**
@@ -59,35 +66,40 @@ class DecisionNode
     public function traverseGameTree(): TraversalResult
     {
         if ($this->depthLeft == 0) {
-            return TraversalResult::onlyEvaluation($this->makeLeafResult());
+            return TraversalResult::withoutMove($this->makeLeafEvaluation());
         }
 
         /* @var $possibleMoves GameState[] */
         $possibleMoves = $this->state->getPossibleMoves();
         if (empty($possibleMoves)) {
-            return TraversalResult::onlyEvaluation($this->makeLeafResult());
+            return TraversalResult::withoutMove($this->makeLeafEvaluation());
         }
 
-        $idealResult = null;
         $idealMove = null;
+        $idealMoveResult = null;
         foreach ($possibleMoves as $move) {
-            $moveResult = $this->getChildResult($move);
+            if (!$this->alphaBeta->isPositiveRange()) {
+                // Subtree became fruitless, return to caller asap
+                break;
+            }
 
-            if ($idealResult === null || $this->isIdealOver($moveResult, $idealResult)) {
-                $idealResult = $moveResult;
+            $moveResult = $this->getChildResult($move);
+            $this->alphaBeta->update($moveResult->evaluation, $this->type);
+            if ($idealMoveResult === null || $this->isIdealOver($moveResult->evaluation, $idealMoveResult->evaluation)) {
                 $idealMove = $move;
+                $idealMoveResult = $moveResult;
             }
         }
 
-        return TraversalResult::create($idealMove, $idealResult);
+        return TraversalResult::create($idealMove, $idealMoveResult->evaluation);
     }
 
     /**
-     * Formulate the evaluation result, this node being a leaf node
+     * Formulate the evaluation, this node being a leaf node
      */
-    private function makeLeafResult(): EvaluationResult
+    private function makeLeafEvaluation(): Evaluation
     {
-        $result = new EvaluationResult();
+        $result = new Evaluation();
         $result->age = $this->depthLeft;
         $result->score = $this->state->evaluateScore($this->objectivePlayer);
         return $result;
@@ -99,28 +111,29 @@ class DecisionNode
      * @param GameState $stateAfterMove The GameState that was created as a
      * result of a possible move.
      */
-    private function getChildResult(GameState $stateAfterMove): EvaluationResult
+    private function getChildResult(GameState $stateAfterMove): TraversalResult
     {
         $nextPlayerIsFriendly = $stateAfterMove->getNextPlayer()->isFriendsWith($this->objectivePlayer);
         $nextDecisionPoint = new static(
             $this->objectivePlayer,
             $stateAfterMove,
             $this->depthLeft - 1,
-            $nextPlayerIsFriendly ? $this->type : $this->type->alternate()
+            $nextPlayerIsFriendly ? NodeType::MAX() : NodeType::MIN(),
+            clone $this->alphaBeta
         );
-        return $nextDecisionPoint->traverseGameTree()->evaluation;
+        return $nextDecisionPoint->traverseGameTree();
     }
 
     /**
-     * Compare two evaluation results
+     * Compare two evaluations
      * The meaning of "best" is decided by the "ideal" member variable
      * comparator
      */
-    private function isIdealOver(EvaluationResult $a, EvaluationResult $b): bool
+    private function isIdealOver(Evaluation $a, Evaluation $b): bool
     {
         $ideal = $this->type == NodeType::MIN()
-            ? EvaluationResult::getWorstComparator()
-            : EvaluationResult::getBestComparator();
+            ? Evaluation::getWorstComparator()
+            : Evaluation::getBestComparator();
         $idealEvaluationResult = $ideal($a, $b);
         return $idealEvaluationResult > 0;
     }

--- a/src/engine/DecisionNode.php
+++ b/src/engine/DecisionNode.php
@@ -66,15 +66,16 @@ class DecisionNode
     public function traverseGameTree(): TraversalResult
     {
         if ($this->depthLeft == 0) {
-            return TraversalResult::withoutMove($this->makeLeafEvaluation());
+            return TraversalResult::withoutMove($this->makeLeafEvaluation(), Analytics::forLeafNode());
         }
 
         /* @var $possibleMoves GameState[] */
         $possibleMoves = $this->state->getPossibleMoves();
         if (empty($possibleMoves)) {
-            return TraversalResult::withoutMove($this->makeLeafEvaluation());
+            return TraversalResult::withoutMove($this->makeLeafEvaluation(), Analytics::forLeafNode());
         }
 
+        $analytics = Analytics::forInternalNode();
         $idealMove = null;
         $idealMoveResult = null;
         foreach ($possibleMoves as $move) {
@@ -84,6 +85,7 @@ class DecisionNode
             }
 
             $moveResult = $this->getChildResult($move);
+            $analytics->add($moveResult->analytics);
             $this->alphaBeta->update($moveResult->evaluation, $this->type);
             if ($idealMoveResult === null || $this->isIdealOver($moveResult->evaluation, $idealMoveResult->evaluation)) {
                 $idealMove = $move;
@@ -91,7 +93,7 @@ class DecisionNode
             }
         }
 
-        return TraversalResult::create($idealMove, $idealMoveResult->evaluation);
+        return TraversalResult::create($idealMove, $idealMoveResult->evaluation, $analytics);
     }
 
     /**

--- a/src/engine/DecisionWithScore.php
+++ b/src/engine/DecisionWithScore.php
@@ -35,7 +35,7 @@ class DecisionWithScore
     public function isBetterThan(DecisionWithScore $other): bool
     {
         if (abs($this->score - $other->score) < self::EPSILON) {
-            // Scores are considered the same, prefer earliest decision
+            // Scores are considered the same, prefer earliest decision. (Shallowest node)
             return $this->age > $other->age;
         }
         return $this->score > $other->score;

--- a/src/engine/Engine.php
+++ b/src/engine/Engine.php
@@ -21,6 +21,12 @@ class Engine
     private $maxDepth;
 
     /**
+     * @var ?Analytics Only available after run, contains statistics about the
+     * execution.
+     */
+    private $analytics;
+
+    /**
      * @param Player $objectivePlayer The player to play as
      * @param int $maxDepth How far ahead should the engine look?
      */
@@ -55,6 +61,15 @@ class Engine
         );
 
         $moveWithEvaluation = $rootNode->traverseGameTree();
+        $this->analytics = $moveWithEvaluation->analytics;
         return $moveWithEvaluation->move;
+    }
+
+    public function getAnalytics(): Analytics
+    {
+        if ($this->analytics === null) {
+            throw new BadMethodCallException('Please run decide() first.');
+        }
+        return $this->analytics;
     }
 }

--- a/src/engine/Engine.php
+++ b/src/engine/Engine.php
@@ -42,16 +42,18 @@ class Engine
         if (!$state->getNextPlayer()->equals($this->objectivePlayer)) {
             throw new BadMethodCallException('It is not this players turn');
         }
-        $topLevelNode = new DecisionNode(
+        if (empty($state->getPossibleMoves())) {
+            throw new RuntimeException('There are no possible moves');
+        }
+
+        $rootNode = new DecisionNode(
             $this->objectivePlayer,
             $state,
             $this->maxDepth,
             NodeType::MAX()
         );
-        $decisionWithScore = $topLevelNode->decide();
-        if ($decisionWithScore->decision === null) {
-            throw new RuntimeException('There are no possible moves');
-        }
-        return $decisionWithScore->decision;
+
+        $moveWithEvaluation = $rootNode->traverseGameTree();
+        return $moveWithEvaluation->move;
     }
 }

--- a/src/engine/Engine.php
+++ b/src/engine/Engine.php
@@ -50,7 +50,8 @@ class Engine
             $this->objectivePlayer,
             $state,
             $this->maxDepth,
-            NodeType::MAX()
+            NodeType::MAX(),
+            AlphaBeta::initial()
         );
 
         $moveWithEvaluation = $rootNode->traverseGameTree();

--- a/src/engine/Engine.php
+++ b/src/engine/Engine.php
@@ -42,11 +42,11 @@ class Engine
         if (!$state->getNextPlayer()->equals($this->objectivePlayer)) {
             throw new BadMethodCallException('It is not this players turn');
         }
-        $topLevelNode = new DecisionPoint(
+        $topLevelNode = new DecisionNode(
             $this->objectivePlayer,
             $state,
             $this->maxDepth,
-            DecisionWithScore::getBestComparator()
+            NodeType::MAX()
         );
         $decisionWithScore = $topLevelNode->decide();
         if ($decisionWithScore->decision === null) {

--- a/src/engine/Evaluation.php
+++ b/src/engine/Evaluation.php
@@ -9,7 +9,7 @@ use Closure;
  * These two concepts are used together so often that it warrants a separate
  * class to be able to carry them around easily.
  */
-class EvaluationResult
+class Evaluation
 {
     const EPSILON = 0.00001;
 
@@ -26,7 +26,7 @@ class EvaluationResult
      */
     public $age;
 
-    public function isBetterThan(EvaluationResult $other): bool
+    public function isBetterThan(Evaluation $other): bool
     {
         if (abs($this->score - $other->score) < self::EPSILON) {
             // Scores are considered the same, prefer earliest decision. (Shallowest node)
@@ -37,14 +37,14 @@ class EvaluationResult
 
     public static function getBestComparator(): Closure
     {
-        return function (EvaluationResult $a, EvaluationResult $b) {
+        return function (Evaluation $a, Evaluation $b) {
             return $a->isBetterThan($b) ? 1 : -1;
         };
     }
 
     public static function getWorstComparator(): Closure
     {
-        return function (EvaluationResult $a, EvaluationResult $b) {
+        return function (Evaluation $a, Evaluation $b) {
             return $b->isBetterThan($a) ? 1 : -1;
         };
     }

--- a/src/engine/EvaluationResult.php
+++ b/src/engine/EvaluationResult.php
@@ -3,21 +3,15 @@
 namespace lucidtaz\minimax\engine;
 
 use Closure;
-use lucidtaz\minimax\game\GameState;
 
 /**
- * Value object containing a decision and its resulting score
+ * Value object containing the result of a decision tree node evaluation
  * These two concepts are used together so often that it warrants a separate
  * class to be able to carry them around easily.
  */
-class DecisionWithScore
+class EvaluationResult
 {
     const EPSILON = 0.00001;
-
-    /**
-     * @var GameState
-     */
-    public $decision = null;
 
     /**
      * @var float Score that results from applying the decision
@@ -32,7 +26,7 @@ class DecisionWithScore
      */
     public $age;
 
-    public function isBetterThan(DecisionWithScore $other): bool
+    public function isBetterThan(EvaluationResult $other): bool
     {
         if (abs($this->score - $other->score) < self::EPSILON) {
             // Scores are considered the same, prefer earliest decision. (Shallowest node)
@@ -43,15 +37,15 @@ class DecisionWithScore
 
     public static function getBestComparator(): Closure
     {
-        return function (DecisionWithScore $a, DecisionWithScore $b) {
-            return $a->isBetterThan($b) ? $a : $b;
+        return function (EvaluationResult $a, EvaluationResult $b) {
+            return $a->isBetterThan($b) ? 1 : -1;
         };
     }
 
     public static function getWorstComparator(): Closure
     {
-        return function (DecisionWithScore $a, DecisionWithScore $b) {
-            return $b->isBetterThan($a) ? $a : $b;
+        return function (EvaluationResult $a, EvaluationResult $b) {
+            return $b->isBetterThan($a) ? 1 : -1;
         };
     }
 }

--- a/src/engine/NodeType.php
+++ b/src/engine/NodeType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace lucidtaz\minimax\engine;
+
+/**
+ * Enum class
+ */
+class NodeType
+{
+    private $value;
+
+    private function __construct()
+    {
+        // Forbid direct construction
+    }
+
+    public static function MIN(): NodeType
+    {
+        $result = new static();
+        $result->value = 'min';
+        return $result;
+    }
+
+    public static function MAX(): NodeType
+    {
+        $result = new static();
+        $result->value = 'max';
+        return $result;
+    }
+
+    public function alternate(): NodeType
+    {
+        if ($this == self::MIN()) {
+            return self::MAX();
+        }
+        return self::MIN();
+    }
+}

--- a/src/engine/NodeType.php
+++ b/src/engine/NodeType.php
@@ -5,13 +5,13 @@ namespace lucidtaz\minimax\engine;
 /**
  * Enum class
  */
-class NodeType
+final class NodeType
 {
     private $value;
 
     private function __construct()
     {
-        // Forbid direct construction
+        // Forbid manual construction
     }
 
     public static function MIN(): NodeType

--- a/src/engine/NodeType.php
+++ b/src/engine/NodeType.php
@@ -27,12 +27,4 @@ class NodeType
         $result->value = 'max';
         return $result;
     }
-
-    public function alternate(): NodeType
-    {
-        if ($this == self::MIN()) {
-            return self::MAX();
-        }
-        return self::MIN();
-    }
 }

--- a/src/engine/TraversalResult.php
+++ b/src/engine/TraversalResult.php
@@ -19,22 +19,22 @@ class TraversalResult
     public $move;
 
     /**
-     * @var EvaluationResult
+     * @var Evaluation
      */
     public $evaluation;
 
-    private function __construct(EvaluationResult $evaluation, GameState $move = null)
+    private function __construct(Evaluation $evaluation, GameState $move = null)
     {
         $this->move = $move;
         $this->evaluation = $evaluation;
     }
 
-    public static function create(GameState $move, EvaluationResult $evaluation): TraversalResult
+    public static function create(GameState $move, Evaluation $evaluation): TraversalResult
     {
         return new static($evaluation, $move);
     }
 
-    public static function onlyEvaluation(EvaluationResult $evaluation): TraversalResult
+    public static function withoutMove(Evaluation $evaluation): TraversalResult
     {
         return new static($evaluation);
     }

--- a/src/engine/TraversalResult.php
+++ b/src/engine/TraversalResult.php
@@ -11,7 +11,7 @@ use lucidtaz\minimax\game\GameState;
  * produce that result, because that's the final answer that the caller is
  * interested in.
  */
-class TraversalResult
+final class TraversalResult
 {
     /**
      * @var ?GameState Empty if the traversed node was a leaf node
@@ -23,19 +23,25 @@ class TraversalResult
      */
     public $evaluation;
 
-    private function __construct(Evaluation $evaluation, GameState $move = null)
+    /**
+     * @var Analytics
+     */
+    public $analytics;
+
+    private function __construct(Evaluation $evaluation, Analytics $analytics, GameState $move = null)
     {
         $this->move = $move;
         $this->evaluation = $evaluation;
+        $this->analytics = $analytics;
     }
 
-    public static function create(GameState $move, Evaluation $evaluation): TraversalResult
+    public static function create(GameState $move, Evaluation $evaluation, Analytics $analytics): TraversalResult
     {
-        return new static($evaluation, $move);
+        return new static($evaluation, $analytics, $move);
     }
 
-    public static function withoutMove(Evaluation $evaluation): TraversalResult
+    public static function withoutMove(Evaluation $evaluation, Analytics $analytics): TraversalResult
     {
-        return new static($evaluation);
+        return new static($evaluation, $analytics);
     }
 }

--- a/src/engine/TraversalResult.php
+++ b/src/engine/TraversalResult.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace lucidtaz\minimax\engine;
+
+use lucidtaz\minimax\game\GameState;
+
+/**
+ * An value type to hold an evaluation result and possibly a move
+ * For tree traversal, technically only the evaluation result is needed.
+ * However, at the root of the tree we need to know which move was selected to
+ * produce that result, because that's the final answer that the caller is
+ * interested in.
+ */
+class TraversalResult
+{
+    /**
+     * @var ?GameState Empty if the traversed node was a leaf node
+     */
+    public $move;
+
+    /**
+     * @var EvaluationResult
+     */
+    public $evaluation;
+
+    private function __construct(EvaluationResult $evaluation, GameState $move = null)
+    {
+        $this->move = $move;
+        $this->evaluation = $evaluation;
+    }
+
+    public static function create(GameState $move, EvaluationResult $evaluation): TraversalResult
+    {
+        return new static($evaluation, $move);
+    }
+
+    public static function onlyEvaluation(EvaluationResult $evaluation): TraversalResult
+    {
+        return new static($evaluation);
+    }
+}

--- a/tests/ReversiTest.php
+++ b/tests/ReversiTest.php
@@ -63,6 +63,7 @@ class ReversiTest extends TestCase
         $this->assertEquals($BLUE, $state->getNextPlayer(), 'Test precondition');
 
         $engine = new Engine($BLUE);
+        /* @var $newState GameState */
         $newState = $engine->decide($state);
 
         $this->assertEquals(4, $newState->board->countOwnedCells($BLUE), 'Blue cell count increased');

--- a/tests/ReversiTest.php
+++ b/tests/ReversiTest.php
@@ -3,6 +3,7 @@
 namespace lucidtaz\minimax\tests;
 
 use BadMethodCallException;
+use lucidtaz\minimax\engine\Engine;
 use lucidtaz\minimax\tests\reversi\GameState;
 use lucidtaz\minimax\tests\reversi\Player;
 use PHPUnit\Framework\TestCase;
@@ -45,6 +46,24 @@ class ReversiTest extends TestCase
 
         $newState = clone $state;
         $newState->makeMove(2, 4);
+
+        $this->assertEquals(4, $newState->board->countOwnedCells($BLUE), 'Blue cell count increased');
+        $this->assertEquals(1, $newState->board->countOwnedCells($RED), 'Red cell count decreased (piece captured)');
+        $this->assertEquals($RED, $newState->getNextPlayer(), 'Player turn proceeded');
+    }
+
+    public function testEngineTakesAMove()
+    {
+        $BLUE = Player::BLUE();
+        $RED = Player::RED();
+
+        $state = new GameState();
+        $this->assertEquals(2, $state->board->countOwnedCells($BLUE), 'Test precondition');
+        $this->assertEquals(2, $state->board->countOwnedCells($RED), 'Test precondition');
+        $this->assertEquals($BLUE, $state->getNextPlayer(), 'Test precondition');
+
+        $engine = new Engine($BLUE);
+        $newState = $engine->decide($state);
 
         $this->assertEquals(4, $newState->board->countOwnedCells($BLUE), 'Blue cell count increased');
         $this->assertEquals(1, $newState->board->countOwnedCells($RED), 'Red cell count decreased (piece captured)');

--- a/tests/ReversiTest.php
+++ b/tests/ReversiTest.php
@@ -78,39 +78,36 @@ class ReversiTest extends TestCase
      * Max depth
      *       | Duration normal
      *       |       | Duration AB pruning
-     * ------+-------+---
-     *     1 |   0.0 |  0.0
-     *     2 |   0.0 |  0.0
-     *     3 |   0.1 |  0.2
-     *     4 |   0.6 |  0.5
-     *     5 |   3   |  1
-     *     6 |  20   |  5
-     *     7 | 165   | 17
-     *
-     * @medium
-     * @todo For determinism it's better to inspect the number of visited nodes
+     *       |       |      | Nodes evaluated normal
+     *       |       |      |       |Nodes evaluated AB pruning
+     * ------+-------+------|-------+--------
+     *     1 |   0.0 |  0.0 |      5 |     5
+     *     2 |   0.0 |  0.0 |     17 |    15
+     *     3 |   0.1 |  0.2 |     85 |    67
+     *     4 |   0.6 |  0.5 |    365 |   169
+     *     5 |   3   |  1   |   2773 |   743
+     *     6 |  20   |  5   |  18595 |  2342
+     *     7 | 165   | 17   | 199309 | 13958
      */
     public function testEngineHandlesLargeSearchSpace()
     {
         $BLUE = Player::BLUE();
         $RED = Player::RED();
-        $maxDepth = 6;
+        $maxDepth = 3;
 
         $state = new GameState();
         $this->assertEquals(2, $state->board->countOwnedCells($BLUE), 'Test precondition');
         $this->assertEquals(2, $state->board->countOwnedCells($RED), 'Test precondition');
         $this->assertEquals($BLUE, $state->getNextPlayer(), 'Test precondition');
 
-        $startTime = microtime(true);
         $engine = new Engine($BLUE, $maxDepth);
         /* @var $newState GameState */
         $newState = $engine->decide($state);
-        $duration = microtime(true) - $startTime;
 
         $this->assertEquals(4, $newState->board->countOwnedCells($BLUE), 'Blue cell count increased');
         $this->assertEquals(1, $newState->board->countOwnedCells($RED), 'Red cell count decreased (piece captured)');
         $this->assertEquals($RED, $newState->getNextPlayer(), 'Player turn proceeded');
 
-        $this->assertLessThan(10, $duration, 'Search duration must be short enough');
+        $this->assertLessThan(70, $engine->getAnalytics()->nodesEvaluated, 'Evaluated nodes must indicate pruning');
     }
 }

--- a/tests/ReversiTest.php
+++ b/tests/ReversiTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace lucidtaz\minimax\tests;
+
+use BadMethodCallException;
+use lucidtaz\minimax\tests\reversi\GameState;
+use lucidtaz\minimax\tests\reversi\Player;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the engine using Reversi
+ *
+ * This is a larger problem space than Tic-Tac-Toe. These tests cover the
+ * performance aspect of the Minimax Engine.
+ */
+class ReversiTest extends TestCase
+{
+    public function testReversiDetectsIllegalMovesNoNeighbors()
+    {
+        $state = new GameState;
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Illegal move');
+        $state->makeMove(0, 0);
+    }
+
+    public function testReversiDetectsIllegalMovesOwnNeighbor()
+    {
+        $state = new GameState;
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Illegal move');
+        $state->makeMove(2, 3);
+    }
+
+    public function testReversiAllowsLegalMove()
+    {
+        $BLUE = Player::BLUE();
+        $RED = Player::RED();
+
+        $state = new GameState();
+        $this->assertEquals(2, $state->board->countOwnedCells($BLUE), 'Test precondition');
+        $this->assertEquals(2, $state->board->countOwnedCells($RED), 'Test precondition');
+        $this->assertEquals($BLUE, $state->getNextPlayer(), 'Test precondition');
+
+        $newState = clone $state;
+        $newState->makeMove(2, 4);
+
+        $this->assertEquals(4, $newState->board->countOwnedCells($BLUE), 'Blue cell count increased');
+        $this->assertEquals(1, $newState->board->countOwnedCells($RED), 'Red cell count decreased (piece captured)');
+        $this->assertEquals($RED, $newState->getNextPlayer(), 'Player turn proceeded');
+    }
+}

--- a/tests/ReversiTest.php
+++ b/tests/ReversiTest.php
@@ -70,4 +70,47 @@ class ReversiTest extends TestCase
         $this->assertEquals(1, $newState->board->countOwnedCells($RED), 'Red cell count decreased (piece captured)');
         $this->assertEquals($RED, $newState->getNextPlayer(), 'Player turn proceeded');
     }
+
+    /**
+     * Verify alpha-beta pruning optimization
+     *
+     * Empyrical test times:
+     * Max depth
+     *       | Duration normal
+     *       |       | Duration AB pruning
+     * ------+-------+---
+     *     1 |   0.0 |  0.0
+     *     2 |   0.0 |  0.0
+     *     3 |   0.1 |  0.2
+     *     4 |   0.6 |  0.5
+     *     5 |   3   |  1
+     *     6 |  20   |  5
+     *     7 | 165   | 17
+     *
+     * @medium
+     * @todo For determinism it's better to inspect the number of visited nodes
+     */
+    public function testEngineHandlesLargeSearchSpace()
+    {
+        $BLUE = Player::BLUE();
+        $RED = Player::RED();
+        $maxDepth = 6;
+
+        $state = new GameState();
+        $this->assertEquals(2, $state->board->countOwnedCells($BLUE), 'Test precondition');
+        $this->assertEquals(2, $state->board->countOwnedCells($RED), 'Test precondition');
+        $this->assertEquals($BLUE, $state->getNextPlayer(), 'Test precondition');
+
+        $startTime = microtime(true);
+        $engine = new Engine($BLUE, $maxDepth);
+        /* @var $newState GameState */
+        $newState = $engine->decide($state);
+        $duration = microtime(true) - $startTime;
+
+        $this->assertEquals(4, $newState->board->countOwnedCells($BLUE), 'Blue cell count increased');
+        $this->assertEquals(1, $newState->board->countOwnedCells($RED), 'Red cell count decreased (piece captured)');
+        $this->assertEquals($RED, $newState->getNextPlayer(), 'Player turn proceeded');
+
+        $this->assertLessThan(10, $duration, 'Search duration must be short enough');
+    }
 }

--- a/tests/reversi/Board.php
+++ b/tests/reversi/Board.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace lucidtaz\minimax\tests\reversi;
+
+use Generator;
+
+/**
+ * 8x8 Reversi board
+ * It simply tracks which players own which cells.
+ */
+class Board
+{
+    /**
+     * @var array Simple 8x8 array of Player objects to denote who owns it.
+     */
+    private $cells;
+
+    public function __construct()
+    {
+        $this->initializeEmptyFields();
+        $this->placeStartingTokens();
+    }
+
+    private function initializeEmptyFields()
+    {
+        $none = Player::NONE();
+        for ($row = 0; $row < 8; $row++) {
+            for ($column = 0; $column < 8; $column++) {
+                $this->cells[$row][$column] = $none;
+            }
+        }
+    }
+
+    private function placeStartingTokens()
+    {
+        $this->cells[3][3] = Player::BLUE();
+        $this->cells[3][4] = Player::RED();
+        $this->cells[4][3] = Player::RED();
+        $this->cells[4][4] = Player::BLUE();
+    }
+
+    public function isWithinBounds($row, $column): bool
+    {
+        return $row >= 0 && $row < 8 && $column >= 0 && $column < 8;
+    }
+
+    /**
+     * Tells which player owns the specified field
+     * Player::NONE() in case the field is not owned.
+     */
+    public function getField($row, $column): Player
+    {
+        return $this->cells[$row][$column];
+    }
+
+    public function fillField(int $row, int $column, Player $owner)
+    {
+        $this->cells[$row][$column] = $owner;
+    }
+
+    public function countOwnedCells(Player $player): int
+    {
+        $ownedCells = 0;
+        foreach ($this->cells as $rowValues) {
+            foreach ($rowValues as $fieldValue) {
+                if ($fieldValue->equals($player)) {
+                    $ownedCells++;
+                }
+            }
+        }
+        return $ownedCells;
+    }
+
+    public function isOwnedBy(int $row, int $column, Player $player): bool
+    {
+        if (!$this->isWithinBounds($row, $column)) {
+            return false;
+        }
+
+        $neighbordField = $this->getField($row, $column);
+        return $neighbordField->equals($player);
+    }
+
+    /**
+     * @return Generator Each element is an (x, y) tuple
+     */
+    public function getEmptyFields(): Generator
+    {
+        foreach ($this->cells as $row => $rowValues) {
+            foreach ($rowValues as $col => $fieldValue) {
+                if ($fieldValue->equals(Player::NONE())) {
+                    yield [$row, $col];
+                }
+            }
+        }
+    }
+}

--- a/tests/reversi/GameState.php
+++ b/tests/reversi/GameState.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace lucidtaz\minimax\tests\reversi;
+
+use BadMethodCallException;
+use Generator;
+use lucidtaz\minimax\game\GameState as GameStateInterface;
+use lucidtaz\minimax\game\Player as PlayerInterface;
+
+class GameState implements GameStateInterface
+{
+    /**
+     * @var Board Game board, keeping track of cell ownership.
+     */
+    public $board;
+
+    /**
+     * @var Player Reference to the player whose turn it currently is.
+     */
+    private $turn;
+
+    /**
+     * @var bool Indicates that the previous player could not make a move.
+     */
+    private $lastPlayerPassed;
+
+    public function __construct()
+    {
+        $this->board = new Board();
+        $this->turn = Player::BLUE();
+        $this->lastPlayerPassed = false;
+    }
+
+    public function __clone()
+    {
+        $this->board = clone $this->board;
+        $this->turn = clone $this->turn;
+    }
+
+    public function makeMove(int $row, int $column)
+    {
+        if (!$this->isLegalMove($row, $column)) {
+            throw new BadMethodCallException('Illegal move');
+        }
+
+        $this->board->fillField($row, $column, $this->turn);
+
+        $anchorPieces = $this->findAnchorPieces($row, $column);
+        $this->capturePieces($row, $column, $anchorPieces);
+
+        $this->lastPlayerPassed = false;
+        $this->proceedPlayer();
+    }
+
+    public function pass()
+    {
+        if ($this->lastPlayerPassed) {
+            throw new BadMethodCallException('Cannot pass after the previous player passed.');
+        }
+        // TODO: Only allow when there are no legal moves
+        $this->lastPlayerPassed = true;
+        $this->proceedPlayer();
+    }
+
+    private function capturePieces(int $moveRow, int $moveColumn, Generator $anchorPieces)
+    {
+        foreach ($anchorPieces as $anchorPiece) {
+            list($anchorRow, $anchorColumn) = $anchorPiece;
+            $dY = $anchorRow <=> $moveRow;
+            $dX = $anchorColumn <=> $moveColumn;
+
+            for ($i = 1; $i < 8; $i++) {
+                $captureFieldX = $moveColumn + $dX * $i;
+                $captureFieldY = $moveRow + $dY * $i;
+                if ($captureFieldX == $anchorColumn && $captureFieldY == $anchorRow) {
+                    break;
+                }
+                $this->board->fillField($captureFieldY, $captureFieldX, $this->turn);
+            }
+        }
+    }
+
+    private function proceedPlayer()
+    {
+        if ($this->turn->equals(Player::BLUE())) {
+            $this->turn = Player::RED();
+        } else {
+            $this->turn = Player::BLUE();
+        }
+    }
+
+    /**
+     * @param Player $player
+     */
+    public function evaluateScore(PlayerInterface $player): float
+    {
+        $opponent = $player->equals(Player::BLUE()) ? Player::RED() : Player::BLUE();
+        return $this->board->countOwnedCells($player) - $this->board->countOwnedCells($opponent);
+    }
+
+    /**
+     * @return GameState[]
+     */
+    public function getPossibleMoves(): array
+    {
+        $possibleMoves = [];
+        foreach ($this->board->getEmptyFields() as $emptyField) {
+            list($row, $col) = $emptyField;
+            if ($this->isLegalMove($row, $col)) {
+                $stateAfterMove = clone $this;
+                $stateAfterMove->makeMove($row, $col);
+                $possibleMoves[] = $stateAfterMove;
+            }
+        }
+        if (empty($possibleMoves) && !$this->lastPlayerPassed) {
+            $passingMove = clone $this;
+            $passingMove->pass();
+            $possibleMoves[] = $passingMove;
+        }
+        return $possibleMoves;
+    }
+
+    private function isLegalMove(int $row, int $column): bool
+    {
+        foreach ($this->findAnchorPieces($row, $column) as $anchorPiece) {
+            // At least one anchor piece found
+            return true;
+        }
+        return false;
+    }
+
+    private function findAnchorPieces(int $row, int $column): Generator
+    {
+        $opponent = $this->turn->equals(Player::BLUE()) ? Player::RED() : Player::BLUE();
+
+        // Check all eight directions for an opponent piece
+        foreach ($this->enumerateDirections() as $direction) {
+            list($directionX, $directionY) = $direction;
+            $inspectCellX = $column + $directionX;
+            $inspectCellY = $row + $directionY;
+
+            if (!$this->board->isOwnedBy($inspectCellY, $inspectCellX, $opponent)) {
+                continue;
+            }
+
+            // Bordering an opponent, check in that direction for the anchor piece
+            for ($i = 2; $i < 8; $i++) {
+                $anchorCellX = $column + $directionX * $i;
+                $anchorCellY = $row + $directionY * $i;
+
+                if ($this->board->isOwnedBy($anchorCellX, $anchorCellY, $this->turn)) {
+                    // We found our anchor piece, move becomes valid
+                    yield [$anchorCellX, $anchorCellY];
+                    break;
+                }
+            }
+        }
+    }
+
+    private function enumerateDirections(): Generator
+    {
+        for ($directionX = -1; $directionX <= 1; $directionX++) {
+            for ($directionY = -1; $directionY <= 1; $directionY++) {
+                if ($directionX != 0 || $directionY != 0) {
+                    yield [$directionX, $directionY];
+                }
+            }
+        }
+    }
+
+    public function getNextPlayer(): PlayerInterface
+    {
+        return $this->turn;
+    }
+}

--- a/tests/reversi/Player.php
+++ b/tests/reversi/Player.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace lucidtaz\minimax\tests\reversi;
+
+use lucidtaz\minimax\game\Player as PlayerInterface;
+
+class Player implements PlayerInterface
+{
+    private $sign;
+
+    public static function NONE(): Player
+    {
+        $result = new Player;
+        $result->sign = ' ';
+        return $result;
+    }
+
+    public static function BLUE(): Player
+    {
+        $result = new Player;
+        $result->sign = 'B';
+        return $result;
+    }
+
+    public static function RED(): Player
+    {
+        $result = new Player;
+        $result->sign = 'R';
+        return $result;
+    }
+
+    /**
+     * @param Player $other
+     */
+    public function equals(PlayerInterface $other): bool
+    {
+        return $other->sign == $this->sign;
+    }
+
+    /**
+     * @param Player $other
+     */
+    public function isFriendsWith(PlayerInterface $other): bool
+    {
+        return $this->equals($other);
+    }
+}

--- a/tests/tictactoe/Board.php
+++ b/tests/tictactoe/Board.php
@@ -101,4 +101,12 @@ class Board
             }
         }
     }
+
+    public function __toString(): string
+    {
+        return
+            "{$this->cells[0][0]}{$this->cells[0][1]}{$this->cells[0][2]}\n" .
+            "{$this->cells[1][0]}{$this->cells[1][1]}{$this->cells[1][2]}\n" .
+            "{$this->cells[2][0]}{$this->cells[2][1]}{$this->cells[2][2]}\n";
+    }
 }

--- a/tests/tictactoe/Player.php
+++ b/tests/tictactoe/Player.php
@@ -44,4 +44,9 @@ class Player implements PlayerInterface
     {
         return $this->equals($other);
     }
+
+    public function __toString(): string
+    {
+        return $this->sign;
+    }
 }


### PR DESCRIPTION
To enable searching a larger space, I'm implementing alpha-beta pruning. However, the code is currently quite unclear when reasoning about a tree structure (when to pass parameters, when to get results back, ...) so there needs to be some refactoring to make it understandable.

Immediate unfinished work:

- [x] Refactor `evaluateMove` according to the docblock todo
- [x] Rename `DecisionWithScore` to something more appropriate, like `EvaluationResult`
- [x] Change timed test to inspect number of visited nodes instead
- [x] Fix scrutinizer suggestions to make classes with a private constructor `final`